### PR TITLE
PCM-2852: Add a case comments uql query api

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Then before pushing your remote branch always rebase to upstream master
     git checkout <branch>
     git rebase master
 
-
 Then verify that everything is still working as you expect it to, test in the browser, then push your remote branch
 
     git push origin <branch name>

--- a/app/common/services/udsService.js
+++ b/app/common/services/udsService.js
@@ -181,6 +181,14 @@ angular.module('RedhatAccess.common').factory('udsService', [
                     }
                 }
             },
+            // This is not to be confused with kase.comments.  This top level comments object allows you to query
+            // /case/comments with custom UQL
+            comments: {
+                get: function (uql) {
+                    return uds.fetchComments(uql);
+
+                }
+            },
             account:{
                 get:function(accountNumber){
                     return uds.fetchAccountDetails(accountNumber);

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "redhat-access-angular-ui-common",
-    "version": "1.1.43",
+    "version": "1.1.44",
     "main": "dist/redhat_access_angular_ui_common.js",
     "dependencies": {
         "angular": "1.2.1",

--- a/dist/redhat_access_angular_ui_common.js
+++ b/dist/redhat_access_angular_ui_common.js
@@ -1,4 +1,4 @@
-/*! redhat_access_angular_ui_common - v1.1.43 - 2016-05-25
+/*! redhat_access_angular_ui_common - v1.1.44 - 2016-06-01
  * Copyright (c) 2016 ;
  * Licensed 
  */
@@ -2071,6 +2071,14 @@ angular.module('RedhatAccess.common').factory('udsService', [
                     put: function(caseNumber,contacts){
                         return uds.addAdditionalContacts(caseNumber,contacts);
                     }
+                }
+            },
+            // This is not to be confused with kase.comments.  This top level comments object allows you to query
+            // /case/comments with custom UQL
+            comments: {
+                get: function (uql) {
+                    return uds.fetchComments(uql);
+
                 }
             },
             account:{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "redhat_access_angular_ui_common",
-    "version": "1.1.43",
+    "version": "1.1.44",
     "dependencies": {},
     "devDependencies": {
         "grunt": "~0.4.1",


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/PCM-2852

Gives the ability to make UQL queries against /case/comments

The changes in https://github.com/redhataccess/udsjs/pull/70 are required for this api to work.
